### PR TITLE
[JinJeon] sidebar 컴포넌트 생성 및 기본 렌더링 구현

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 
 import Address from '@components/Address';
 import LoginButton from '@components/LoginButton';
-import SideBar from '@components/SideBar';
+import SideBar from '@components/Sidebar';
 
 const Header = () => {
   return (

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,8 +1,8 @@
 import styled from 'styled-components';
 
 import Address from '@components/Address';
-import * as S from '@components/Header/Header.style';
 import LoginButton from '@components/LoginButton';
+import SideBar from '@components/SideBar';
 
 const Header = () => {
   return (
@@ -16,7 +16,7 @@ const Header = () => {
       <div>
         <span>알림 </span>
         <LoginButton />
-        <span>메뉴</span>
+        <SideBar />
       </div>
     </Wrapper>
   );

--- a/src/components/LoginButton/index.tsx
+++ b/src/components/LoginButton/index.tsx
@@ -1,6 +1,7 @@
-import React, { useState } from 'react';
+import { useRecoilState } from 'recoil';
 
 import Portal from '@components/Portal';
+import { modalState } from '@store/portal';
 
 import * as S from './LoginButton.style';
 
@@ -9,7 +10,7 @@ const loginMention = '카카오로 로그인하고\n여러 사람들과 쉐어�
 const kakaoLoginMention = '카카오로 로그인';
 
 const LoginButton = () => {
-  const [isPortal, setIsPortal] = useState(false);
+  const [isPortal, setIsPortal] = useRecoilState(modalState);
 
   return (
     <button onClick={() => setIsPortal(true)}>

--- a/src/components/LoginButton/index.tsx
+++ b/src/components/LoginButton/index.tsx
@@ -14,7 +14,7 @@ const LoginButton = () => {
   return (
     <button onClick={() => setIsPortal(true)}>
       {LOGIN}
-      <Portal setIsPortal={setIsPortal} isPortal={isPortal}>
+      <Portal setIsPortal={setIsPortal} isPortal={isPortal} type='modal'>
         <S.LoginWrapper>
           {loginMention}
           <S.KakaoLoginButton>{kakaoLoginMention}</S.KakaoLoginButton>

--- a/src/components/Portal/Portal.style.tsx
+++ b/src/components/Portal/Portal.style.tsx
@@ -47,6 +47,12 @@ export const PortalContent = styled.div<PortalStylePropsType>`
     `}
 
     ${portalType === 'sidebar' &&
+    !isPortal &&
+    css`
+      animation: fadeout 0.5s;
+    `}
+
+    ${portalType === 'sidebar' &&
     css`
       animation: slideout 0.5s;
       position: absolute;

--- a/src/components/Portal/Portal.style.tsx
+++ b/src/components/Portal/Portal.style.tsx
@@ -1,43 +1,88 @@
 import styled, { css } from 'styled-components';
 
-type PortalBackgroundPropsType = {
+type PortalType = 'modal' | 'sidebar';
+
+type PortalStylePropsType = {
   isPortal: boolean;
+  portalType: PortalType;
 };
 
-export const PortalBackground = styled.div<PortalBackgroundPropsType>`
+export const PortalBackground = styled.div<PortalStylePropsType>`
   width: 100%;
   height: 100%;
   display: none;
   position: fixed;
   inset: 0;
   background-color: #00000040; // 투명도 조절 필요
-  justify-content: center;
-  align-items: center;
-
   animation: fadein 0.5s;
-  ${({ isPortal }) =>
-    !isPortal &&
+
+  ${({ isPortal, portalType }) => css`
+    ${!isPortal &&
     css`
       animation: fadeout 0.5s;
     `}
+
+    ${portalType === 'modal' &&
+    css`
+      justify-content: center;
+      align-items: center;
+    `}
+  `}
 `;
 
-export const PortalCloseButton = styled.button`
-  position: absolute;
-  left: 2rem;
-  top: 2rem;
-  width: 8%;
-  height: 8%;
-`;
-
-export const PortalContent = styled.div`
-  position: relative;
-  box-shadow: 3px 3px 8px rgba(0, 0, 0, 0.2);
+export const PortalContent = styled.div<PortalStylePropsType>`
   background-color: white;
-  border-radius: 2rem;
-  padding: 2rem;
-  width: 30%;
-  height: 25%;
-  min-width: 300px;
-  min-height: 300px;
+
+  ${({ portalType, isPortal }) => css`
+    ${portalType === 'modal' &&
+    css`
+      box-shadow: 3px 3px 8px rgba(0, 0, 0, 0.2);
+      position: relative;
+      border-radius: 1.5rem;
+      padding: 2.5rem;
+      width: 30%;
+      height: 25%;
+      min-width: 300px;
+      min-height: 300px;
+    `}
+
+    ${portalType === 'sidebar' &&
+    css`
+      animation: slideout 0.5s;
+      position: absolute;
+      right: 0;
+      top: 0;
+      border-radius: 1.5rem 0 0 1.5rem;
+      width: 60%;
+      height: 100%;
+      max-width: 300px;
+      padding: 2rem;
+    `}
+
+    ${portalType === 'sidebar' &&
+    !isPortal &&
+    css`
+      animation: slidein 0.5s;
+    `}
+  `}
+`;
+
+export const PortalCloseButton = styled.button<{ portalType: PortalType }>`
+  position: absolute;
+  width: 1.5rem;
+  height: 1.5rem;
+
+  ${({ portalType }) => css`
+    ${portalType === 'modal' &&
+    css`
+      right: 1rem;
+      top: 1rem;
+    `}
+
+    ${portalType === 'sidebar' &&
+    css`
+      right: 0;
+      top: 0;
+    `}
+  `}
 `;

--- a/src/components/Portal/index.tsx
+++ b/src/components/Portal/index.tsx
@@ -8,6 +8,7 @@ type PortalPropsType = {
   isPortal: boolean;
   setIsPortal: React.Dispatch<React.SetStateAction<boolean>>;
   children: ReactNode;
+  type: 'modal' | 'sidebar';
 };
 
 const PortalRoot = ({ children }: { children: ReactNode }) => {
@@ -15,7 +16,7 @@ const PortalRoot = ({ children }: { children: ReactNode }) => {
   return element && createPortal(children, element);
 };
 
-const Portal = ({ setIsPortal, isPortal, children }: PortalPropsType) => {
+const Portal = ({ setIsPortal, isPortal, children, type }: PortalPropsType) => {
   const backgroundRef = useRef<HTMLDivElement>(null);
 
   const closePortal = (event: MouseEvent) => {
@@ -39,13 +40,20 @@ const Portal = ({ setIsPortal, isPortal, children }: PortalPropsType) => {
   return (
     <PortalRoot>
       <S.PortalBackground
+        portalType={type}
         ref={backgroundRef}
         onClick={closePortal}
         isPortal={isPortal}
         onAnimationEnd={handleAnimationEnd}
       >
-        <S.PortalContent onClick={(event) => event.stopPropagation()}>
-          <S.PortalCloseButton onClick={closePortal}>X</S.PortalCloseButton>
+        <S.PortalContent
+          onClick={(event) => event.stopPropagation()}
+          portalType={type}
+          isPortal={isPortal}
+        >
+          <S.PortalCloseButton onClick={closePortal} portalType={type}>
+            X
+          </S.PortalCloseButton>
           {children}
         </S.PortalContent>
       </S.PortalBackground>

--- a/src/components/SideBar/Sidebar.style.tsx
+++ b/src/components/SideBar/Sidebar.style.tsx
@@ -1,0 +1,3 @@
+import styled from 'styled-components';
+
+export const SideBarWrapper = styled.button``;

--- a/src/components/SideBar/Sidebar.style.tsx
+++ b/src/components/SideBar/Sidebar.style.tsx
@@ -9,4 +9,5 @@ export const SideBarWrapper = styled.div`
 export const SideBarContent = styled.button`
   text-align: left;
   height: 2rem;
+  width: 100%;
 `;

--- a/src/components/SideBar/Sidebar.style.tsx
+++ b/src/components/SideBar/Sidebar.style.tsx
@@ -1,3 +1,12 @@
 import styled from 'styled-components';
 
-export const SideBarWrapper = styled.button``;
+export const SideBarWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+`;
+
+export const SideBarContent = styled.button`
+  text-align: left;
+  height: 2rem;
+`;

--- a/src/components/SideBar/Sidebar.style.tsx
+++ b/src/components/SideBar/Sidebar.style.tsx
@@ -3,11 +3,17 @@ import styled from 'styled-components';
 export const SideBarWrapper = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+
+  > :first-child {
+    border-bottom: solid 1px black;
+  }
+  > :last-child {
+    border-top: solid 1px black;
+  }
 `;
 
 export const SideBarContent = styled.button`
   text-align: left;
-  height: 2rem;
+  height: 3rem;
   width: 100%;
 `;

--- a/src/components/SideBar/index.tsx
+++ b/src/components/SideBar/index.tsx
@@ -1,20 +1,48 @@
-import { useState } from 'react';
+import { useRecoilState, useSetRecoilState } from 'recoil';
 
 import Portal from '@components/Portal';
+import { sidebarState, modalState } from '@store/portal';
 
 import * as S from './Sidebar.style';
 
-const SideBar = () => {
-  const [isPortal, setIsPortal] = useState(false);
+const Sidebar = () => {
+  const [isSidebarPortal, setIsSidebarPortal] = useRecoilState(sidebarState);
+  const setIsModalPortal = useSetRecoilState(modalState);
+
+  const showSideBar = () => {
+    setIsSidebarPortal(true);
+  };
+
+  const showLoginModal = () => {
+    setIsSidebarPortal(false);
+    setIsModalPortal(true);
+  };
+
+  const sideBarContentsInfo = [
+    { id: 0, name: '로그인', clickHandler: () => showLoginModal() },
+    { id: 1, name: '홈' },
+    { id: 2, name: '배달 쉐어' },
+    { id: 3, name: '재료 쉐어' },
+    { id: 4, name: '쉐어 작성' },
+    { id: 5, name: '기타' },
+  ];
+
+  const sidebarContents = sideBarContentsInfo.map(({ id, name, clickHandler }) => {
+    return (
+      <S.SideBarContent key={id} onClick={clickHandler}>
+        {name}
+      </S.SideBarContent>
+    );
+  });
 
   return (
-    <button onClick={() => setIsPortal(true)}>
+    <button onClick={showSideBar}>
       SIDEBAR
-      <Portal isPortal={isPortal} setIsPortal={setIsPortal} type='sidebar'>
-        <S.SideBarWrapper>SIDEBAR CONTENT</S.SideBarWrapper>
+      <Portal isPortal={isSidebarPortal} setIsPortal={setIsSidebarPortal} type='sidebar'>
+        <S.SideBarWrapper>{sidebarContents}</S.SideBarWrapper>
       </Portal>
     </button>
   );
 };
 
-export default SideBar;
+export default Sidebar;

--- a/src/components/SideBar/index.tsx
+++ b/src/components/SideBar/index.tsx
@@ -1,3 +1,4 @@
+import { Link, useLocation } from 'react-router-dom';
 import { useRecoilState, useSetRecoilState } from 'recoil';
 
 import Portal from '@components/Portal';
@@ -8,35 +9,30 @@ import * as S from './Sidebar.style';
 const Sidebar = () => {
   const [isSidebarPortal, setIsSidebarPortal] = useRecoilState(sidebarState);
   const setIsModalPortal = useSetRecoilState(modalState);
-
-  const showSideBar = () => {
-    setIsSidebarPortal(true);
-  };
-
-  const showLoginModal = () => {
-    setIsSidebarPortal(false);
-    setIsModalPortal(true);
-  };
-
+  const { pathname } = useLocation();
   const sideBarContentsInfo = [
-    { id: 0, name: '로그인', clickHandler: () => showLoginModal() },
-    { id: 1, name: '홈' },
-    { id: 2, name: '배달 쉐어' },
-    { id: 3, name: '재료 쉐어' },
-    { id: 4, name: '쉐어 작성' },
-    { id: 5, name: '기타' },
+    { id: 0, name: '로그인', clickHandler: () => setIsModalPortal(true) },
+    { id: 1, name: '홈', link: '/' },
+    { id: 2, name: '배달 쉐어', link: '/share-list' },
+    { id: 3, name: '재료 쉐어', link: '/share-list' },
+    { id: 4, name: '쉐어 작성', link: 'share-form' },
+    { id: 5, name: '기타', link: 'notice' },
   ];
 
-  const sidebarContents = sideBarContentsInfo.map(({ id, name, clickHandler }) => {
+  const sidebarContents = sideBarContentsInfo.map(({ id, name, clickHandler, link }) => {
+    const clickButtonHandler = () => {
+      setIsSidebarPortal(false);
+      if (clickHandler) clickHandler();
+    };
     return (
-      <S.SideBarContent key={id} onClick={clickHandler}>
-        {name}
-      </S.SideBarContent>
+      <Link to={link || pathname} key={id}>
+        <S.SideBarContent onClick={clickButtonHandler}>{name}</S.SideBarContent>
+      </Link>
     );
   });
 
   return (
-    <button onClick={showSideBar}>
+    <button onClick={() => setIsSidebarPortal(true)}>
       SIDEBAR
       <Portal isPortal={isSidebarPortal} setIsPortal={setIsSidebarPortal} type='sidebar'>
         <S.SideBarWrapper>{sidebarContents}</S.SideBarWrapper>

--- a/src/components/SideBar/index.tsx
+++ b/src/components/SideBar/index.tsx
@@ -1,0 +1,20 @@
+import { useState } from 'react';
+
+import Portal from '@components/Portal';
+
+import * as S from './Sidebar.style';
+
+const SideBar = () => {
+  const [isPortal, setIsPortal] = useState(false);
+
+  return (
+    <button onClick={() => setIsPortal(true)}>
+      SIDEBAR
+      <Portal isPortal={isPortal} setIsPortal={setIsPortal} type='sidebar'>
+        <S.SideBarWrapper>SIDEBAR CONTENT</S.SideBarWrapper>
+      </Portal>
+    </button>
+  );
+};
+
+export default SideBar;

--- a/src/store/portal.ts
+++ b/src/store/portal.ts
@@ -1,0 +1,11 @@
+import { atom } from 'recoil';
+
+export const modalState = atom<boolean>({
+  key: 'modal',
+  default: false,
+});
+
+export const sidebarState = atom<boolean>({
+  key: 'sidebar',
+  default: false,
+});

--- a/src/styles/GlobalStyle.tsx
+++ b/src/styles/GlobalStyle.tsx
@@ -38,6 +38,24 @@ const GlobalStyle = createGlobalStyle`
         opacity: 0;
       }
     }
+
+    @keyframes slideout {
+      from {
+        margin-right: -30%;
+      }
+      to {
+        margin-right: 0;
+      }
+    }
+
+    @keyframes slidein {
+      from {
+        margin-right: 0;
+      }
+      to {
+        margin-right: -30%;
+      }
+    }
   `}
 `;
 


### PR DESCRIPTION
## 📃 Description

- 헤더의 메뉴 버튼 클릭 시 사이드바가 나오도록 설정
- 사이드바가 나올 때 ∙ 들어갈 때 애니메이션이 적용되도록 설정
- 사이드바 구현 시 기존 사용된 Portal 컴포넌트 활용
- Portal의 상태를 나타내는 recoil atom(modalState, sidebarState) 추가
- 사이드바 내의 각 버튼에 대한 기능 설정 (로그인 포탈 생성 ∙ 링크 이동)

## 📸 Screenshot

![Jul-26](https://user-images.githubusercontent.com/67730358/180900193-15c70f35-10b9-486d-a62e-623361e56917.gif)

